### PR TITLE
Fix issue with Jenkins runner being disabled when not using harness helm

### DIFF
--- a/application/skeleton/config/Shared/config_local.php
+++ b/application/skeleton/config/Shared/config_local.php
@@ -175,7 +175,7 @@ $config[RabbitMqEnv::RABBITMQ_CONNECTIONS][$CURRENT_STORE][RabbitMqEnv::RABBITMQ
 // ---------- Scheduler
 $config[SchedulerConstants::ENABLED_SCHEDULERS] = [];
 
-if (getenv('HAS_JENKINS_RUNNER') === 'true') {
+if (getenv('HAS_JENKINS_RUNNER') ?: 'true' === 'true') {
     $config[SchedulerConstants::ENABLED_SCHEDULERS] = [
         SchedulerConfig::SCHEDULER_JENKINS,
     ];


### PR DESCRIPTION
A client doesn't use the harness's helm values, so this isn't inherently turned on.