### PR TITLE
Add Spryker classmap for autoloading

### DIFF
--- a/application/skeleton/composer-harness.json.twig
+++ b/application/skeleton/composer-harness.json.twig
@@ -23,7 +23,11 @@
   "autoload-dev": {
     "psr-4": {
       "Acceptance\\": "features/bootstrap"
-    }
+    },
+    "classmap": [
+      "vendor/spryker",
+      "vendor/spryker-shop"
+    ]
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This tells Composer to build up a classmap for Spryker and Spryker Shop modules to improve the performance of autoloading on development and pipeline environments.