### PR TITLE
Add getSignalsForGracefulWorkerShutdown() to QueueConfig

### DIFF
--- a/application/overlay/src/Pyz/Zed/Queue/QueueConfig.php
+++ b/application/overlay/src/Pyz/Zed/Queue/QueueConfig.php
@@ -27,6 +27,19 @@ class QueueConfig extends SprykerQueueConfig
     }
 
     /**
+     * @return list<int>
+     */
+    public function getSignalsForGracefulWorkerShutdown(): array
+    {
+        return [
+            static::SIGINT,
+            static::SIGQUIT,
+            static::SIGABRT,
+            static::SIGTERM,
+        ];
+    }
+
+    /**
      * @return array
      */
     protected function getQueueReceiverOptions()


### PR DESCRIPTION
## 📖  Description

The harness is already doing an override (`getQueueProcessTimeout()`) to add the process timeout to fix issues with queues not completing during `app install`. The method `getSignalsForGracefulWorkerShutdown()` was introduced in Spryker 2021.08, but it's not in the workspace harness yet.